### PR TITLE
Update for Minecraft 1.21.5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
- - Fixed enchantment glints not working
- - Switched legacy Stonecutter out in favor of the newer [Stonecutter](https://stonecutter.kikugie.dev/)
- - Fixed 1.19.4 port
- - Fixed 1.20.1 port
- - Fixed 1.20.4 port
+- Fixed enchantment glints not working
+- Switched legacy Stonecutter out in favor of the newer [Stonecutter](https://stonecutter.kikugie.dev/)
+- Fixed 1.19.4 port
+- Fixed 1.20.1 port
+- Fixed 1.20.4 port
+- Added support for Minecraft 1.21.5

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/mixin/types/enchantment/ItemRendererMixin.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/mixin/types/enchantment/ItemRendererMixin.java
@@ -4,8 +4,11 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.json.ModelTransformation;
+/*? <1.21.5 {*/
 import net.minecraft.client.render.model.json.ModelTransformationMode;
+/*?} else {*/
+import net.minecraft.client.render.model.json.ModelTransformation;
+/*?}*/
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
@@ -28,14 +31,24 @@ public class ItemRendererMixin {
             CONTAINER.setContext(new CITContext(stack, world, entity));
     }
 
-    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", at = @At("HEAD"))
-    private void citresewn$enchantment$startApplyingItem(ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
+    @Inject(method =
+            /*? <1.21.5 {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?} else {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?}*/, at = @At("HEAD"))
+    private void citresewn$enchantment$startApplyingItem(ItemStack stack, /*? <1.21.5 {*//*ModelTransformationMode*//*?} else {*//*ModelTransformation*//*?}*/ renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
         if (CONTAINER.active())
             CONTAINER.apply();
     }
 
-    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", at = @At("RETURN"))
-    private void citresewn$enchantment$stopApplyingItem(ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
+    @Inject(method =
+            /*? <1.21.5 {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?} else {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?}*/, at = @At("RETURN"))
+    private void citresewn$enchantment$stopApplyingItem(ItemStack stack, /*? <1.21.5 {*//*ModelTransformationMode*//*?} else {*//*ModelTransformation*//*?}*/ renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
         if (CONTAINER.active())
             CONTAINER.setContext(null);
     }

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/mixin/types/item/ItemRendererMixin.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/mixin/types/item/ItemRendererMixin.java
@@ -4,8 +4,11 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.item.ItemModels;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.json.ModelTransformation;
+/*? <1.21.5 {*/
 import net.minecraft.client.render.model.json.ModelTransformationMode;
+/*?} else {*/
+import net.minecraft.client.render.model.json.ModelTransformation;
+/*?}*/
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
@@ -56,8 +59,13 @@ public class ItemRendererMixin {
         }
     }
 
-    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", at = @At("HEAD"))
-    private void citresewn$fixMojankCITsContext(ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
+    @Inject(method =
+            /*? <1.21.5 {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?} else {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?}*/, at = @At("HEAD"))
+    private void citresewn$fixMojankCITsContext(ItemStack stack, /*? <1.21.5 {*//*ModelTransformationMode*//*?} else {*//*ModelTransformation*//*?}*/ renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
         if (!CONTAINER.active() || citresewn$mojankCITModel == null)
             return;
 

--- a/defaults/versions/1.21.5/gradle.properties
+++ b/defaults/versions/1.21.5/gradle.properties
@@ -1,0 +1,6 @@
+mod.target-mc=1.21.5
+publish.target-mc=1.21.5
+deps.yarn=1.21.5+build.1
+deps.fabric-api=0.104.0+1.21.5
+deps.modmenu=11.0.2
+deps.cloth-config=15.0.140

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,8 +21,8 @@ plugins {
 }
 
 stonecutter.create(rootProject) {
-    versions '1.21', '1.20.4', '1.20.1', '1.19.4'
+    versions '1.21.5', '1.21', '1.20.4', '1.20.1', '1.19.4'
     branch 'defaults'
 
-    vcsVersion = '1.21'
+    vcsVersion = '1.21.5'
 }

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -1,5 +1,5 @@
 plugins.apply "dev.kikugie.stonecutter"
-stonecutter.active "1.21" /* [SC] DO NOT EDIT */
+stonecutter.active "1.21.5" /* [SC] DO NOT EDIT */
 
 stonecutter.registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) { 
     setGroup "project"

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -1,0 +1,6 @@
+mod.target-mc=1.21.5
+publish.target-mc=1.21.5
+deps.yarn=1.21.5+build.1
+deps.fabric-api=0.104.0+1.21.5
+deps.modmenu=11.0.2
+deps.cloth-config=15.0.140


### PR DESCRIPTION
## Summary
- support Minecraft 1.21.5
- document new 1.21.5 compatibility in the changelog
- fix newline in version configs
- adjust rendering mixins for updated rendering APIs

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685f045b3fb4832b9ce447587bb127b0

## Summary by Sourcery

Add support for Minecraft 1.21.5 across the project by updating version configurations, mixin targets, and documentation.

New Features:
- Add Minecraft 1.21.5 compatibility and include it in the Stonecutter plugin versions.

Enhancements:
- Adjust rendering mixins to conditionally use the updated ModelTransformation API for 1.21.5.
- Fix newline handling in version configuration files.

Build:
- Include 1.21.5 in settings.gradle Stonecutter versions and set the VCS version accordingly.
- Add dedicated gradle.properties files for the 1.21.5 target in both defaults and root version directories.

Documentation:
- Document Minecraft 1.21.5 compatibility in the changelog.