### PR TITLE
Update for Minecraft 1.21.5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
- - Fixed enchantment glints not working
- - Switched legacy Stonecutter out in favor of the newer [Stonecutter](https://stonecutter.kikugie.dev/)
- - Fixed 1.19.4 port
- - Fixed 1.20.1 port
- - Fixed 1.20.4 port
+- Fixed enchantment glints not working
+- Switched legacy Stonecutter out in favor of the newer [Stonecutter](https://stonecutter.kikugie.dev/)
+- Fixed 1.19.4 port
+- Fixed 1.20.1 port
+- Fixed 1.20.4 port
+- Added support for Minecraft 1.21.5

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,14 @@ loom {
 
 java {
     withSourcesJar()
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
     archivesBaseName = property('mod.jarname')
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release.set(17)
 }
 
 processResources {
@@ -58,9 +62,9 @@ jar {
 
 if (stonecutter.current.isActive) {
     rootProject.tasks.register('buildActive') {
-        setGroup 'project'
+        group = 'project'
 
-        dependsOn tasks.getByName('build')
+        dependsOn tasks.named('build')
     }
 
     plugins.apply 'com.modrinth.minotaur'
@@ -98,7 +102,7 @@ if (stonecutter.current.isActive) {
     }
 
     rootProject.tasks.register('publishActive') {
-        setGroup 'project'
+        group = 'project'
 
         if (gradle.startParameter.taskNames.contains(it.name)) {
             System.out.println("Type the task name to confirm (${it.name}): ")
@@ -108,12 +112,12 @@ if (stonecutter.current.isActive) {
             }
         }
 
-        Task remapJarTask = tasks.getByName 'remapJar'
-        Task curseforgeTask = tasks.getByName 'curseforge'
-        Task modrinthTask = tasks.getByName 'modrinth'
+        TaskProvider<Task> remapJarTask = tasks.named('remapJar')
+        TaskProvider<Task> curseforgeTask = tasks.named('curseforge')
+        TaskProvider<Task> modrinthTask = tasks.named('modrinth')
 
         dependsOn remapJarTask, curseforgeTask, modrinthTask
-        curseforgeTask.mustRunAfter remapJarTask
-        modrinthTask.mustRunAfter remapJarTask
+        curseforgeTask.configure { mustRunAfter remapJarTask }
+        modrinthTask.configure { mustRunAfter remapJarTask }
     }
 }

--- a/defaults/build.gradle
+++ b/defaults/build.gradle
@@ -45,10 +45,14 @@ loom {
 
 java {
     withSourcesJar()
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
     archivesBaseName = "${property('mod.jarname')}-defaults"
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release.set(17)
 }
 
 processResources {
@@ -79,10 +83,10 @@ if (stonecutter.current.isActive) {
     }
 
     rootProject.tasks.named('publishActive') {
-        Task remapJarTask = tasks.getByName 'remapJar'
-        Task modrinthTask = tasks.getByName 'modrinth'
+        TaskProvider<Task> remapJarTask = tasks.named('remapJar')
+        TaskProvider<Task> modrinthTask = tasks.named('modrinth')
 
         dependsOn remapJarTask, modrinthTask
-        modrinthTask.mustRunAfter remapJarTask
+        modrinthTask.configure { mustRunAfter remapJarTask }
     }
 }

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/mixin/types/enchantment/ItemRendererMixin.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/mixin/types/enchantment/ItemRendererMixin.java
@@ -4,8 +4,11 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.*;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.json.ModelTransformation;
+/*? <1.21.5 {*/
 import net.minecraft.client.render.model.json.ModelTransformationMode;
+/*?} else {*/
+import net.minecraft.client.render.model.json.ModelTransformation;
+/*?}*/
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
@@ -28,14 +31,24 @@ public class ItemRendererMixin {
             CONTAINER.setContext(new CITContext(stack, world, entity));
     }
 
-    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", at = @At("HEAD"))
-    private void citresewn$enchantment$startApplyingItem(ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
+    @Inject(method =
+            /*? <1.21.5 {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?} else {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?}*/, at = @At("HEAD"))
+    private void citresewn$enchantment$startApplyingItem(ItemStack stack, /*? <1.21.5 {*//*ModelTransformationMode*//*?} else {*//*ModelTransformation*//*?}*/ renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
         if (CONTAINER.active())
             CONTAINER.apply();
     }
 
-    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", at = @At("RETURN"))
-    private void citresewn$enchantment$stopApplyingItem(ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
+    @Inject(method =
+            /*? <1.21.5 {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?} else {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?}*/, at = @At("RETURN"))
+    private void citresewn$enchantment$stopApplyingItem(ItemStack stack, /*? <1.21.5 {*//*ModelTransformationMode*//*?} else {*//*ModelTransformation*//*?}*/ renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
         if (CONTAINER.active())
             CONTAINER.setContext(null);
     }

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/mixin/types/item/ItemRendererMixin.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/mixin/types/item/ItemRendererMixin.java
@@ -4,8 +4,11 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.item.ItemModels;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.json.ModelTransformation;
+/*? <1.21.5 {*/
 import net.minecraft.client.render.model.json.ModelTransformationMode;
+/*?} else {*/
+import net.minecraft.client.render.model.json.ModelTransformation;
+/*?}*/
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
@@ -56,8 +59,13 @@ public class ItemRendererMixin {
         }
     }
 
-    @Inject(method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", at = @At("HEAD"))
-    private void citresewn$fixMojankCITsContext(ItemStack stack, ModelTransformationMode renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
+    @Inject(method =
+            /*? <1.21.5 {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformationMode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?} else {*/
+            "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V"
+            /*?}*/, at = @At("HEAD"))
+    private void citresewn$fixMojankCITsContext(ItemStack stack, /*? <1.21.5 {*//*ModelTransformationMode*//*?} else {*//*ModelTransformation*//*?}*/ renderMode, boolean leftHanded, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay, BakedModel model, CallbackInfo ci) {
         if (!CONTAINER.active() || citresewn$mojankCITModel == null)
             return;
 

--- a/defaults/versions/1.21.5/gradle.properties
+++ b/defaults/versions/1.21.5/gradle.properties
@@ -1,0 +1,6 @@
+mod.target-mc=1.21.5
+publish.target-mc=1.21.5
+deps.yarn=1.21.5+build.1
+deps.fabric-api=0.104.0+1.21.5
+deps.modmenu=11.0.2
+deps.cloth-config=15.0.140

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,8 +21,8 @@ plugins {
 }
 
 stonecutter.create(rootProject) {
-    versions '1.21', '1.20.4', '1.20.1', '1.19.4'
+    versions '1.21.5', '1.21', '1.20.4', '1.20.1', '1.19.4'
     branch 'defaults'
 
-    vcsVersion = '1.21'
+    vcsVersion = '1.21.5'
 }

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -1,7 +1,7 @@
 plugins.apply "dev.kikugie.stonecutter"
-stonecutter.active "1.21" /* [SC] DO NOT EDIT */
+stonecutter.active "1.21.5" /* [SC] DO NOT EDIT */
 
-stonecutter.registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) { 
-    setGroup "project"
+stonecutter.registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) {
+    group = "project"
     ofTask "build"
 }

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -1,0 +1,6 @@
+mod.target-mc=1.21.5
+publish.target-mc=1.21.5
+deps.yarn=1.21.5+build.1
+deps.fabric-api=0.104.0+1.21.5
+deps.modmenu=11.0.2
+deps.cloth-config=15.0.140


### PR DESCRIPTION
## Summary
- support Minecraft 1.21.5
- document new 1.21.5 compatibility in the changelog
- fix newline in version configs
- adjust rendering mixins for updated rendering APIs
- update Gradle wrapper and scripts for Gradle 9 compatibility

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685f045b3fb4832b9ce447587bb127b0

## Summary by Sourcery

Enable compatibility with Minecraft 1.21.5 by adding version-specific configurations, updating build scripts to Gradle 9 and Java toolchains, adjusting rendering mixins for the new rendering API, and updating the changelog.

New Features:
- Add support for Minecraft 1.21.5 with corresponding version properties

Enhancements:
- Migrate Java compilation to use the Gradle toolchain API with release settings and upgrade the Gradle wrapper to 8.9
- Modernize Gradle task references with named providers and update task grouping
- Adjust mixin injection signatures in item and enchantment renderers to accommodate the updated rendering API

Documentation:
- Document new Minecraft 1.21.5 compatibility in the changelog